### PR TITLE
Removing the reference to HTTPS not supported.

### DIFF
--- a/init/wstuncli.default
+++ b/init/wstuncli.default
@@ -5,7 +5,7 @@
 TOKEN=
 
 # Local server to which HTTP requests are forwarded, this is the web server to which requests
-# are being tunneled. Currently only http is supported (not https).
+# are being tunneled.
 SERVER=http://localhost
 
 # Remote websockets tunnel endpoint to which this client connects to


### PR DESCRIPTION
Removing the reference to https not supported. Refer to http://docs.rightscale.com/faq/wstunnel_setup.html