### PR TITLE
Add Support for Wstuncli port range

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ version.go
 
 # vendor
 vendor/
+build/
+.vscode/

--- a/tunnel/wstuncli.go
+++ b/tunnel/wstuncli.go
@@ -33,6 +33,7 @@ import (
 
 	//"crypto/tls"
 	"encoding/base64"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -414,7 +415,7 @@ func (t *WSTunnelClient) wsDialerLocalPort(network string, addr string, ports []
 		err = fmt.Errorf("WS: error connecting with local port %s: %s", port, err.Error())
 		t.Log.Info(err.Error())
 	}
-	err = fmt.Errorf("WS: Could not connect using any of the ports in range: ", strings.Join(ports, ","))
+	err = errors.New("WS: Could not connect using any of the ports in range: " + strings.Join(ports, ","))
 	return nil, err
 }
 

--- a/tunnel/wstuncli.go
+++ b/tunnel/wstuncli.go
@@ -420,8 +420,10 @@ func (t *WSTunnelClient) wsProxyDialer(network string, addr string) (conn net.Co
 				server, _ := net.ResolveTCPAddr("tcp", addr)
 				conn, err = net.DialTCP(network, client, server)
 				if err != nil {
-					return conn, nil
+					return nil, err
 				}
+				
+				return conn, nil
 			}
 		} else {
 			return net.Dial(network, addr)

--- a/tunnel/wstuncli.go
+++ b/tunnel/wstuncli.go
@@ -422,7 +422,7 @@ func (t *WSTunnelClient) wsProxyDialer(network string, addr string) (conn net.Co
 				if err != nil {
 					return nil, err
 				}
-				
+
 				return conn, nil
 			}
 		} else {

--- a/tunnel/wstuncli.go
+++ b/tunnel/wstuncli.go
@@ -462,7 +462,7 @@ func (t *WSTunnelClient) wsDialerLocalPort(network string, addr string, ports []
 		err = fmt.Errorf("WS: error connecting with local port %d: %s", port, err.Error())
 		t.Log.Info(err.Error())
 	}
-	strPorts := strings.Trim(strings.Join(strings.Fields(fmt.Sprint(ports)), ","), "[]")
+	strPorts := fmt.Sprint(ports)
 	err = errors.New("WS: Could not connect using any of the ports in range: " + strPorts)
 	return nil, err
 }

--- a/tunnel/wstuncli.go
+++ b/tunnel/wstuncli.go
@@ -107,7 +107,7 @@ func NewWSTunnelClient(args []string) *WSTunnelClient {
 	var statf *string = cliFlag.String("statusfile", "", "path for status file")
 	var proxy *string = cliFlag.String("proxy", "",
 		"use HTTPS proxy http://user:pass@hostname:port")
-	var cliport *string = cliFlag.String("client-ports", "",
+	var cliports *string = cliFlag.String("client-ports", "",
 		"comma separated list of client listening ports ex: --client-ports 8000..8100,8300..8400,8500,8505")
 
 	cliFlag.Parse(args)
@@ -161,9 +161,11 @@ func NewWSTunnelClient(args []string) *WSTunnelClient {
 		wstunCli.Proxy = proxyURL
 	}
 
-	if *cliport != "" {
-		portList := strings.Split(*cliport, ",")
-		var clientPorts []int
+	if *cliports != "" {
+		portList := strings.Split(*cliports, ",")
+		clientPorts := []int{}
+		log15.Info("Attempting to start client with ports: " + *cliports)
+
 		for _, v := range portList {
 			if strings.Contains(v, "..") {
 				k := strings.Split(v, "..")
@@ -188,13 +190,14 @@ func NewWSTunnelClient(args []string) *WSTunnelClient {
 					intPort := n
 					clientPorts = append(clientPorts, intPort)
 				}
+			} else {
+				intPort, err := strconv.Atoi(v)
+				if err != nil {
+					log15.Crit(fmt.Sprintf("Can not convert %q to integer", v))
+					os.Exit(1)
+				}
+				clientPorts = append(clientPorts, intPort)
 			}
-			intPort, err := strconv.Atoi(v)
-			if err != nil {
-				log15.Crit(fmt.Sprintf("Can not convert %q to integer", v))
-				os.Exit(1)
-			}
-			clientPorts = append(clientPorts, intPort)
 		}
 		wstunCli.ClientPorts = clientPorts
 	}

--- a/tunnel/wstuncli.go
+++ b/tunnel/wstuncli.go
@@ -444,8 +444,7 @@ func (wsc *WSConnection) writeStatus() {
 
 func (t *WSTunnelClient) wsDialerLocalPort(network string, addr string, ports []int) (conn net.Conn, err error) {
 	for _, port := range ports {
-		strPort := strconv.Itoa(port)
-		client, err := net.ResolveTCPAddr("tcp", ":"+strPort)
+		client, err := net.ResolveTCPAddr("tcp", fmt.Sprintf(":%d", port))
 		if err != nil {
 			return nil, err
 		}
@@ -462,8 +461,8 @@ func (t *WSTunnelClient) wsDialerLocalPort(network string, addr string, ports []
 		err = fmt.Errorf("WS: error connecting with local port %d: %s", port, err.Error())
 		t.Log.Info(err.Error())
 	}
-	strPorts := fmt.Sprint(ports)
-	err = errors.New("WS: Could not connect using any of the ports in range: " + strPorts)
+
+	err = errors.New("WS: Could not connect using any of the ports in range: " + fmt.Sprint(ports))
 	return nil, err
 }
 

--- a/tunnel/wstuncli.go
+++ b/tunnel/wstuncli.go
@@ -431,10 +431,10 @@ func (t *WSTunnelClient) wsDialerLocalPort(network string, addr string, ports []
 func (t *WSTunnelClient) wsProxyDialer(network string, addr string) (conn net.Conn, err error) {
 	if t.Proxy == nil {
 		if len(t.ClientPorts) != 0 {
-			t.wsDialerLocalPort(network, addr, t.ClientPorts)
-		} else {
-			return net.Dial(network, addr)
+			conn, err = t.wsDialerLocalPort(network, addr, t.ClientPorts)
+			return conn, err
 		}
+		return net.Dial(network, addr)
 	}
 
 	conn, err = net.Dial("tcp", t.Proxy.Host)

--- a/tunnel/wstuncli.go
+++ b/tunnel/wstuncli.go
@@ -169,18 +169,18 @@ func NewWSTunnelClient(args []string) *WSTunnelClient {
 				k := strings.Split(v, "..")
 				bInt, err := strconv.Atoi(k[0])
 				if err != nil {
-					log15.Crit(fmt.Sprintf("Invalid Port Assignment: %q %v", *cliport, err))
+					log15.Crit(fmt.Sprintf("Invalid Port Assignment: %q in range: %q", k[0], v))
 					os.Exit(1)
 				}
 
 				eInt, err := strconv.Atoi(k[1])
 				if err != nil {
-					log15.Crit(fmt.Sprintf("Invalid Port Assignment: %q %v", *cliport, err))
+					log15.Crit(fmt.Sprintf("Invalid Port Assignment: %q in range: %q", k[1], v))
 					os.Exit(1)
 				}
 
 				if eInt < bInt {
-					log15.Crit(fmt.Sprintf("End port can not be greater than beginning port %q %v", *cliport, err))
+					log15.Crit(fmt.Sprintf("End port %d can not be less than beginning port %d", eInt, bInt))
 					os.Exit(1)
 				}
 
@@ -189,7 +189,11 @@ func NewWSTunnelClient(args []string) *WSTunnelClient {
 					clientPorts = append(clientPorts, intPort)
 				}
 			}
-			intPort, _ := strconv.Atoi(v)
+			intPort, err := strconv.Atoi(v)
+			if err != nil {
+				log15.Crit(fmt.Sprintf("Can not convert %q to integer", v))
+				os.Exit(1)
+			}
 			clientPorts = append(clientPorts, intPort)
 		}
 		wstunCli.ClientPorts = clientPorts


### PR DESCRIPTION
As some firewalls don't like to allow connections to upper port ranges, allow specifying that range. 
https://gist.github.com/higebu/96c09c8f03113997fd9a5338ca99764a
The algo will need to handle "port already in use" errors and retry with a different number and I guess just fail if there are no ports left.