### PR TITLE
Apply client argument "insecure" to gorilla's websocket dialer too

### DIFF
--- a/tunnel/wstuncli.go
+++ b/tunnel/wstuncli.go
@@ -236,12 +236,12 @@ func (t *WSTunnelClient) Start() error {
 		return fmt.Errorf("Must specify rendez-vous token using -token option")
 	}
 
+	tlsClientConfig := tls.Config{}
 	if t.Insecure {
 		t.Log.Info("Accepting unverified SSL certs from local HTTPS servers")
+		tlsClientConfig.InsecureSkipVerify = true
 		tr := &http.Transport{
-			TLSClientConfig: &tls.Config{
-				InsecureSkipVerify: true,
-			},
+			TLSClientConfig: &tlsClientConfig,
 		}
 		httpClient = http.Client{Transport: tr}
 	}
@@ -275,6 +275,7 @@ func (t *WSTunnelClient) Start() error {
 				NetDial:         t.wsProxyDialer,
 				ReadBufferSize:  100 * 1024,
 				WriteBufferSize: 100 * 1024,
+				TLSClientConfig: &tlsClientConfig,
 			}
 			h := make(http.Header)
 			h.Add("Origin", t.Token)


### PR DESCRIPTION
On connect to a server with self-signed certificate with argument "-insecure" I still encounter the following error
```
INFO[11-12|13:24:59] WS   Opening                             pkg=WStuncli url=wss://127.0.0.1:8080/_tunnel token=blabl...
EROR[11-12|13:24:59] Error opening connection                 pkg=WStuncli err="x509: certificate signed by unknown authority" info=
```
When digging into the code I figured, that the error is thrown by websocket.Dialer before the self-configured HTTP client is even used.
[gorilla/websocket exposes a similar configuration interface.](https://github.com/gorilla/websocket/blob/master/client.go#L68) Accordingly I maintain a commonly updated configuration and apply them to both.