### PR TITLE
Use io.Reader to avoid file size limits

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,3 +13,5 @@ require (
 	golang.org/x/sys v0.0.0-20210806184541-e5e7981a1069 // indirect
 	gopkg.in/inconshreveable/log15.v2 v2.0.0-20200109203555-b30bc20e4fd1
 )
+
+replace github.com/imdario/mergo => dario.cat/mergo latest

--- a/tunnel/ws.go
+++ b/tunnel/ws.go
@@ -83,7 +83,7 @@ func wsHandler(t *WSTunnelServer, w http.ResponseWriter, r *http.Request) {
 	// Spawn goroutine to read responses
 	go wsReader(rs, ws, t.WSTimeout, ch, &rs.readWG)
 	// Send requests
-	wsWriter(rs, ws, t.WSTimeout, ch)
+	wsWriter(rs, ws, ch)
 }
 
 func wsSetPingHandler(t *WSTunnelServer, ws *websocket.Conn, rs *remoteServer) {
@@ -108,7 +108,7 @@ func wsSetPingHandler(t *WSTunnelServer, ws *websocket.Conn, rs *remoteServer) {
 }
 
 // Pick requests off the RemoteServer queue and send them into the tunnel
-func wsWriter(rs *remoteServer, ws *websocket.Conn, wsTimeout time.Duration, ch chan int) {
+func wsWriter(rs *remoteServer, ws *websocket.Conn, ch chan int) {
 	var req *remoteRequest
 	var err error
 	for {
@@ -133,7 +133,7 @@ func wsWriter(rs *remoteServer, ws *websocket.Conn, wsTimeout time.Duration, ch 
 			continue
 		}
 		// write the request into the tunnel
-		ws.SetWriteDeadline(time.Now().Add(wsTimeout))
+		ws.SetWriteDeadline(time.Time{}) // no timeout, there's the ping-pong for that
 		var w io.WriteCloser
 		w, err = ws.NextWriter(websocket.BinaryMessage)
 		// got an error, reply with a "hey, retry" to the request handler

--- a/tunnel/ws.go
+++ b/tunnel/ws.go
@@ -83,7 +83,7 @@ func wsHandler(t *WSTunnelServer, w http.ResponseWriter, r *http.Request) {
 	// Spawn goroutine to read responses
 	go wsReader(rs, ws, t.WSTimeout, ch, &rs.readWG)
 	// Send requests
-	wsWriter(rs, ws, ch)
+	wsWriter(rs, ws, t.WSTimeout, ch)
 }
 
 func wsSetPingHandler(t *WSTunnelServer, ws *websocket.Conn, rs *remoteServer) {
@@ -108,7 +108,7 @@ func wsSetPingHandler(t *WSTunnelServer, ws *websocket.Conn, rs *remoteServer) {
 }
 
 // Pick requests off the RemoteServer queue and send them into the tunnel
-func wsWriter(rs *remoteServer, ws *websocket.Conn, ch chan int) {
+func wsWriter(rs *remoteServer, ws *websocket.Conn, wsTimeout time.Duration, ch chan int) {
 	var req *remoteRequest
 	var err error
 	for {
@@ -133,7 +133,7 @@ func wsWriter(rs *remoteServer, ws *websocket.Conn, ch chan int) {
 			continue
 		}
 		// write the request into the tunnel
-		ws.SetWriteDeadline(time.Now().Add(time.Minute))
+		ws.SetWriteDeadline(time.Now().Add(wsTimeout))
 		var w io.WriteCloser
 		w, err = ws.NextWriter(websocket.BinaryMessage)
 		// got an error, reply with a "hey, retry" to the request handler

--- a/tunnel/ws.go
+++ b/tunnel/ws.go
@@ -3,13 +3,12 @@
 package tunnel
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"html"
 	"io"
-	"io/ioutil"
 	"net/http"
+	"sync"
 
 	// imported per documentation - https://golang.org/pkg/net/http/pprof/
 	_ "net/http/pprof"
@@ -77,14 +76,12 @@ func wsHandler(t *WSTunnelServer, w http.ResponseWriter, r *http.Request) {
 	go func() {
 		rs.remoteName, rs.remoteWhois = ipAddrLookup(t.Log, rs.remoteAddr)
 	}()
-	// Set safety limits
-	ws.SetReadLimit(100 * 1024 * 1024)
 	// Start timeout handling
 	wsSetPingHandler(t, ws, rs)
 	// Create synchronization channel
 	ch := make(chan int, 2)
 	// Spawn goroutine to read responses
-	go wsReader(rs, ws, t.WSTimeout, ch)
+	go wsReader(rs, ws, t.WSTimeout, ch, &rs.readWG)
 	// Send requests
 	wsWriter(rs, ws, ch)
 }
@@ -170,11 +167,15 @@ func wsWriter(rs *remoteServer, ws *websocket.Conn, ch chan int) {
 }
 
 // Read responses from the tunnel and fulfill pending requests
-func wsReader(rs *remoteServer, ws *websocket.Conn, wsTimeout time.Duration, ch chan int) {
+func wsReader(rs *remoteServer, ws *websocket.Conn, wsTimeout time.Duration, ch chan int, readWG *sync.WaitGroup) {
 	var err error
 	logToken := cutToken(rs.token)
 	// continue reading until we get an error
 	for {
+		// wait if another response is being sent
+		readWG.Wait()
+		// increment the WaitGroup counter
+		readWG.Add(1)
 		ws.SetReadDeadline(time.Time{}) // no timeout, there's the ping-pong for that
 		// read a message from the tunnel
 		var t int
@@ -195,13 +196,6 @@ func wsReader(rs *remoteServer, ws *websocket.Conn, wsTimeout time.Duration, ch 
 		if err != nil {
 			break
 		}
-		// read request itself, the size is limited by the SetReadLimit on the websocket
-		var buf []byte
-		buf, err = ioutil.ReadAll(r)
-		if err != nil {
-			break
-		}
-		rs.log.Info("WS   RCV", "id", id, "ws", wsp(ws), "len", len(buf))
 		// try to match request
 		rs.requestSetMutex.Lock()
 		req := rs.requestSet[id]
@@ -209,20 +203,24 @@ func wsReader(rs *remoteServer, ws *websocket.Conn, wsTimeout time.Duration, ch 
 		rs.requestSetMutex.Unlock()
 		// let's see...
 		if req != nil {
-			rb := responseBuffer{response: bytes.NewBuffer(buf)}
+			rb := responseBuffer{response: r}
 			// try to enqueue response
 			select {
 			case req.replyChan <- rb:
 				// great!
+				rs.log.Info("WS   RCV enqueued response", "id", id, "ws", wsp(ws))
 			default:
+				readWG.Done()
 				rs.log.Info("WS   RCV can't enqueue response", "id", id, "ws", wsp(ws))
 			}
 		} else {
+			readWG.Done()
 			rs.log.Info("%s #%d: WS   RCV orphan response", "id", id, "ws", wsp(ws))
 		}
 	}
 	// print error message
 	if err != nil {
+		readWG.Done()
 		rs.log.Info("WS   closing", "token", logToken, "err", err.Error(), "ws", wsp(ws))
 	}
 	// close up shop

--- a/tunnel/wstuncli.go
+++ b/tunnel/wstuncli.go
@@ -364,8 +364,6 @@ func (wsc *WSConnection) handleRequests() {
 			wsc.Log.Warn("WS   invalid message type", "type", typ)
 			break
 		}
-		// give the sender a minute to produce the request
-		wsc.ws.SetReadDeadline(time.Now().Add(time.Minute))
 		// read request id
 		var id int16
 		_, err = fmt.Fscanf(io.LimitReader(r, 4), "%04x", &id)

--- a/tunnel/wstuncli.go
+++ b/tunnel/wstuncli.go
@@ -758,7 +758,7 @@ func (wsc *WSConnection) writeResponseMessage(id int16, resp *http.Response) {
 	wsWriterMutex.Lock()
 	defer wsWriterMutex.Unlock()
 	// Write response into the tunnel
-	wsc.ws.SetWriteDeadline(time.Now().Add(wsc.tun.Timeout))
+	wsc.ws.SetWriteDeadline(time.Time{}) // separate ping-pong routine does timeout
 	w, err := wsc.ws.NextWriter(websocket.BinaryMessage)
 	// got an error, reply with a "hey, retry" to the request handler
 	if err != nil {

--- a/tunnel/wstuncli.go
+++ b/tunnel/wstuncli.go
@@ -758,7 +758,7 @@ func (wsc *WSConnection) writeResponseMessage(id int16, resp *http.Response) {
 	wsWriterMutex.Lock()
 	defer wsWriterMutex.Unlock()
 	// Write response into the tunnel
-	wsc.ws.SetWriteDeadline(time.Now().Add(time.Minute))
+	wsc.ws.SetWriteDeadline(time.Now().Add(wsc.tun.Timeout))
 	w, err := wsc.ws.NextWriter(websocket.BinaryMessage)
 	// got an error, reply with a "hey, retry" to the request handler
 	if err != nil {

--- a/tunnel/wstunsrv.go
+++ b/tunnel/wstunsrv.go
@@ -373,7 +373,7 @@ func getResponse(t *WSTunnelServer, req *remoteRequest, w http.ResponseWriter, r
 	case resp := <-req.replyChan:
 		// if there's no error just respond
 		if resp.err == nil {
-			code := writeResponse(t, rs, w, resp.response)
+			code := writeResponse(rs, w, resp.response)
 			req.log.Info("HTTP RET", "status", code)
 			return
 		}
@@ -499,7 +499,7 @@ var censoredHeaders = []string{
 }
 
 // Write an HTTP response from a byte buffer into a ResponseWriter
-func writeResponse(t *WSTunnelServer, rs *remoteServer, w http.ResponseWriter, r io.Reader) int {
+func writeResponse(rs *remoteServer, w http.ResponseWriter, r io.Reader) int {
 	defer rs.readWG.Done()
 	resp, err := http.ReadResponse(bufio.NewReader(r), nil)
 	if err != nil {

--- a/tunnel/wstunsrv.go
+++ b/tunnel/wstunsrv.go
@@ -354,7 +354,9 @@ func getResponse(t *WSTunnelServer, req *remoteRequest, w http.ResponseWriter, r
 	// and release the lock on reading new requests
 	defer func() {
 		rs.RetireRequest(req)
-		rs.readCond.Signal()
+		if !retry {
+			rs.readCond.Signal()
+		}
 	}()
 
 	// enqueue request

--- a/tunnel/wstunsrv.go
+++ b/tunnel/wstunsrv.go
@@ -51,7 +51,7 @@ type token string
 
 type responseBuffer struct {
 	err      error
-	response *bytes.Buffer
+	response io.Reader
 }
 
 // A request for a remote server
@@ -77,6 +77,7 @@ type remoteServer struct {
 	requestSet      map[int16]*remoteRequest // all requests in queue/flight indexed by ID
 	requestSetMutex sync.Mutex
 	log             log15.Logger
+	readWG          sync.WaitGroup
 }
 
 //WSTunnelServer a wstunnel server construct
@@ -372,7 +373,7 @@ func getResponse(t *WSTunnelServer, req *remoteRequest, w http.ResponseWriter, r
 	case resp := <-req.replyChan:
 		// if there's no error just respond
 		if resp.err == nil {
-			code := writeResponse(w, resp.response)
+			code := writeResponse(t, rs, w, resp.response)
 			req.log.Info("HTTP RET", "status", code)
 			return
 		}
@@ -498,8 +499,9 @@ var censoredHeaders = []string{
 }
 
 // Write an HTTP response from a byte buffer into a ResponseWriter
-func writeResponse(w http.ResponseWriter, buf *bytes.Buffer) int {
-	resp, err := http.ReadResponse(bufio.NewReader(buf), nil)
+func writeResponse(t *WSTunnelServer, rs *remoteServer, w http.ResponseWriter, r io.Reader) int {
+	defer rs.readWG.Done()
+	resp, err := http.ReadResponse(bufio.NewReader(r), nil)
 	if err != nil {
 		log15.Info("WriteResponse: can't parse incoming response", "err", err)
 		w.WriteHeader(506)
@@ -512,6 +514,7 @@ func writeResponse(w http.ResponseWriter, buf *bytes.Buffer) int {
 	copyHeader(w.Header(), resp.Header)
 	w.WriteHeader(resp.StatusCode)
 	io.Copy(w, resp.Body)
+	resp.Body.Close()
 	return resp.StatusCode
 }
 

--- a/tunnel/wstunsrv.go
+++ b/tunnel/wstunsrv.go
@@ -77,7 +77,8 @@ type remoteServer struct {
 	requestSet      map[int16]*remoteRequest // all requests in queue/flight indexed by ID
 	requestSetMutex sync.Mutex
 	log             log15.Logger
-	readWG          sync.WaitGroup
+	readMutex       sync.Mutex               // ensure that no more than one goroutine calls the websocket read methods concurrently
+	readCond        *sync.Cond               // (NextReader, SetReadDeadline, SetPingHandler, ...)
 }
 
 //WSTunnelServer a wstunnel server construct
@@ -350,8 +351,10 @@ func getResponse(t *WSTunnelServer, req *remoteRequest, w http.ResponseWriter, r
 	}
 
 	// Ensure we retire the request when we pop out of this function
+	// and release the lock on reading new requests
 	defer func() {
 		rs.RetireRequest(req)
+		rs.readCond.Signal()
 	}()
 
 	// enqueue request
@@ -373,7 +376,7 @@ func getResponse(t *WSTunnelServer, req *remoteRequest, w http.ResponseWriter, r
 	case resp := <-req.replyChan:
 		// if there's no error just respond
 		if resp.err == nil {
-			code := writeResponse(rs, w, resp.response)
+			code := writeResponse(w, resp.response)
 			req.log.Info("HTTP RET", "status", code)
 			return
 		}
@@ -427,6 +430,7 @@ func (t *WSTunnelServer) getRemoteServer(tok token, create bool) *remoteServer {
 		requestSet:   make(map[int16]*remoteRequest),
 		log:          log15.New("token", cutToken(tok)),
 	}
+	rs.readCond = sync.NewCond(&rs.readMutex)
 	t.serverRegistry[tok] = rs
 	return rs
 }
@@ -499,8 +503,7 @@ var censoredHeaders = []string{
 }
 
 // Write an HTTP response from a byte buffer into a ResponseWriter
-func writeResponse(rs *remoteServer, w http.ResponseWriter, r io.Reader) int {
-	defer rs.readWG.Done()
+func writeResponse(w http.ResponseWriter, r io.Reader) int {
 	resp, err := http.ReadResponse(bufio.NewReader(r), nil)
 	if err != nil {
 		log15.Info("WriteResponse: can't parse incoming response", "err", err)


### PR DESCRIPTION
Currently the (download) file size is limited at 100MB.
If only this constant is increased, the server has to buffer all content in memory before passing it on.

In this PR we use an io.Reader to process everything as a stream.
Also we remove the file size limits and expose some timeouts to the command line timeout values of server and client.